### PR TITLE
Patch to add development dependency to get specs to pass

### DIFF
--- a/daybreak.gemspec
+++ b/daybreak.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.licenses      = ["MIT"]
   gem.version       = Daybreak::VERSION
+  gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'ruby-prof'
 end


### PR DESCRIPTION
Hi -- interesting project.  In this pull request I've added a reference to "minitest" to get bundler to install all of the development dependencies.
