### PR TITLE
make compact! subclass friendly

### DIFF
--- a/lib/daybreak/db.rb
+++ b/lib/daybreak/db.rb
@@ -135,7 +135,7 @@ module Daybreak
     def compact!
       # Create a new temporary file
       tmp_file = Tempfile.new File.basename(@file_name)
-      copy_db  = DB.new tmp_file.path
+      copy_db  = self.class.new tmp_file.path
 
       # Copy the database key by key into the temporary table
       each do |key, i|


### PR DESCRIPTION
compact! had a reference to DB in it, so that if you have a subclass (such as the JSONDB example), running compact! would re-encode your data in the wrong format. This patch changes it to create the new blank db with the same format as the original. 
