### PR TITLE
Correct errant URI

### DIFF
--- a/README
+++ b/README
@@ -9,4 +9,4 @@ Daybreak is faster than other ruby options like pstore or dbm.
 
 $ gem install daybreak
 
-You can find detailed documentation at http://propublica.github.com/daybreak.
+You can find detailed documentation at http://propublica.github.io/daybreak.


### PR DESCRIPTION
The ".com" URI may have been correct at one point in the past.  I don't recall for sure but I think GitHub may have changed the domain used for project sites.

The repo's URI is also broken, but I can't (AFAIK) submit a PR to change that.  

And the "API Docs" link on https://propublica.github.io/daybreak/ is also broken.